### PR TITLE
FEATURE: Allow invalid plural keys

### DIFF
--- a/lib/messageformat.rb
+++ b/lib/messageformat.rb
@@ -12,16 +12,17 @@ module MessageFormat
     class CompileError < StandardError
     end
 
-    attr_reader :locale, :messages, :context
+    attr_reader :locale, :messages, :context, :strict
 
-    def initialize(locale, messages)
+    def initialize(locale, messages, strict: true)
       @locale = locale
       @messages = messages
+      @strict = strict
       @context = init_context
     end
 
     def compile
-      context.call("compileMessageFormat", locale, messages)
+      context.call("compileMessageFormat", locale, messages, strict)
     rescue MiniRacer::RuntimeError => e
       raise CompileError.new(cause: e)
     end
@@ -35,8 +36,8 @@ module MessageFormat
           context.load(File.expand_path("../dist/messageformat.js", __dir__))
           context.load(File.expand_path("../dist/compilemodule.js", __dir__))
           context.eval(<<~JS)
-            function compileMessageFormat(locale, messages) {
-              const mf = new MessageFormat(locale);
+            function compileMessageFormat(locale, messages, strict) {
+              const mf = new MessageFormat(locale, { strictPluralKeys: strict });
               return compileModule(mf, messages);
             }
           JS

--- a/spec/lib/messageformat_spec.rb
+++ b/spec/lib/messageformat_spec.rb
@@ -4,8 +4,9 @@ require "spec_helper"
 
 describe MessageFormat do
   describe ".compile" do
-    subject { MessageFormat.compile(locale, messages) }
+    subject { MessageFormat.compile(locale, messages, strict:) }
 
+    let(:strict) { true }
     let(:locale) { "en" }
     let(:messages) do
       {
@@ -68,6 +69,40 @@ describe MessageFormat do
 
       it "compiles messages properly" do
         expect(subject).must_equal expected_output
+      end
+    end
+
+    describe "when messages contain invalid rules" do
+      let(:messages) do
+        {
+          a: "A {TYPE} example.",
+          b: "This has {COUNT, plural, one{one member} many{# members} other{# members}}.",
+          c: "We have {P, number, percent} code coverage.",
+        }
+      end
+
+      describe "when in strict mode" do
+        it "raises an error" do
+          expect { subject }.must_raise MessageFormat::Compiler::CompileError
+        end
+      end
+
+      describe "when not in strict mode" do
+        let(:strict) { false }
+        let(:expected_output) { <<~JS.chomp }
+          import { number, plural } from "@messageformat/runtime";
+          import { en } from "@messageformat/runtime/lib/cardinals";
+          import { numberPercent } from "@messageformat/runtime/lib/formatters";
+          export default {
+            a: (d) => "A " + d.TYPE + " example.",
+            b: (d) => "This has " + plural(d.COUNT, 0, en, { one: "one member", many: number("en", d.COUNT, 0) + " members", other: number("en", d.COUNT, 0) + " members" }) + ".",
+            c: (d) => "We have " + numberPercent(d.P, "en") + " code coverage."
+          }
+        JS
+
+        it "compiles messages properly" do
+          expect(subject).must_equal expected_output
+        end
       end
     end
   end


### PR DESCRIPTION
This PR introduces a new option, `strict:`. By default, its value is `true` so if invalid plural keys are provided, an exception will be raised (this is the current behavior).

Now, when calling `MessageFormat.compile` with `strict: false`, if there are invalid plural keys (`many` for English, for example), no exception will be thrown, and the JS code will be returned.